### PR TITLE
chore(remove duplicate): Removed duplicate no-var rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ module.exports = {
     "prefer-rest-params": 2,
     "prefer-spread": 2,
     "yield-star-spacing": 2,
-    "no-var": 2,
 
     "object-curly-spacing": [ 2, "always" ],
     "quotes": [ 2, "single", "avoid-escape" ],


### PR DESCRIPTION
Was looking through and noticed the duplicate no-var rule.

We love semicolons, so `"semi": [ 2, "never" ]` is a deal breaker for us btw ;)