### PR TITLE
Remove overly stringent rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ export default {
     'no-shadow': 'warn',
     'no-undef-init': 'error',
     'no-undef': 'error',
-    'no-unused-expressions': 'warn',
     'no-unused-vars': 'warn',
     'no-var': 'error',
     'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],


### PR DESCRIPTION
This rule is not as innocuous as it seems. Existing code is frequently in violation but upon inspection the warning provided by the rule would not improve any material aspects of code quality